### PR TITLE
Put example for `controller_addresses`

### DIFF
--- a/how-to/use_terraform.rst
+++ b/how-to/use_terraform.rst
@@ -72,7 +72,7 @@ Now create a file called ``main.tf`` with the following content:
         }
 
         provider "juju" {
-            controller_addresses = "<address of your controller>"
+            controller_addresses = "<address of your controller>" # (e.g., "jimm:443")
 
             client_id     = "<clientID>"
             client_secret = "<clientSecret>"


### PR DESCRIPTION
This is a minor improvement, to hint to the port number `:443`.