### PR TITLE
Fixed links

### DIFF
--- a/contribute.rst
+++ b/contribute.rst
@@ -30,5 +30,5 @@ footer of every page.
 For this documentation we use Sphinx and reStructuredText (reST), which is the default plain text markup language used by Sphinx.
 Here are some useful resources on reStructuredText:
 
-- `Sphinx reStructuredText Primer <https://tinyurl.com/rstprimer>`_
+- `Sphinx reStructuredText Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
 - `reStructuredText style guide <https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/>`_ 

--- a/contribute.rst
+++ b/contribute.rst
@@ -30,5 +30,6 @@ footer of every page.
 For this documentation we use Sphinx and reStructuredText (reST), which is the default plain text markup language used by Sphinx.
 Here are some useful resources on reStructuredText:
 
+.. wokeignore:rule=master
 - `Sphinx reStructuredText Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
 - `reStructuredText style guide <https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/>`_ 

--- a/how-to/add_controller.rst
+++ b/how-to/add_controller.rst
@@ -94,7 +94,7 @@ Deploy controller
 
     ``juju status  --format json | jq '.applications.haproxy.units["haproxy/0"]["public-address"]'``
 
-10.  Go to the `Route 53 dashboard <https://us-east-1.console.aws.amazon.com/route53/v2/home>`_.
+10.  Go to the `Route 53 dashboard <https://us-east-1.console.aws.amazon.com/route53/v2/home>`__.
 
 11.  Add an A record for the deployed controller and the DNS name specified in step 1 with the IP obtained in step 9.
 
@@ -102,7 +102,7 @@ Deploy controller
 
     ``juju run-action --wait certbot/0 get-certificate  agree-tos=true aws-access-key-id=<Access key ID> aws-secret-access-key=<Secret access key> domains=<dns name specified in step 1 (jimm.canonical.example.com)> email=<Your email address>  plugin=dns-route53``
 
-13.  Install the JAAS snap that you download from `here <https://drive.google.com/file/d/1LiOvVpVQ13V3x3l2PhgS2fTHDUtCEe7p/view?usp=sharing>`_.
+13.  Install the JAAS snap that you download from `here <https://drive.google.com/file/d/1LiOvVpVQ13V3x3l2PhgS2fTHDUtCEe7p/view?usp=sharing>`__.
 
 14. To add the bootstrapped controller to JIMM we need to create a controller-information document. To do this, run the following command:
 


### PR DESCRIPTION
Fixed errors observed when running `make linkcheck` which was blocking doc rebuild. The same issue is present on the v3 branch.