### PR TITLE
Remove unnecesary added extras

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -14,11 +14,3 @@ jobs:
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
     with:
       working-directory: '.'
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build with warnings as errors
-        run: make check-html-build

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,7 @@ run: install
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 html: install
-	. $(VENV); $(SPHINXBUILD) -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
-
-check-html-build: install
-	. $(VENV); $(SPHINXBUILD) -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -E --fail-on-warning --keep-going $(SPHINXOPTS)
+	. $(VENV); $(SPHINXBUILD) -W --keep-going -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
 
 epub: install
 	. $(VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)


### PR DESCRIPTION
Removes the extra build action recently added because RTD can do it automatically once enabled (which it should be now).
I.e. On this PR you should see a check that built the docs and if you click details, will take you to a built version of the docs.