### PR TITLE
CSS-8607 Architecture doc

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -41,6 +41,8 @@ ReadMe
 reST
 reStructuredText
 RTD
+scalability
+stateful
 subdirectories
 subfolders
 subtree
@@ -48,4 +50,5 @@ Ubuntu
 UI
 UUID
 VM
+websocket
 YAML

--- a/TODO.md
+++ b/TODO.md
@@ -3,12 +3,10 @@
 The following document describes missing JAAS documentation as well as any docs that need to be modernized.
 
 ## Missing Docs
-- JAAS architecture
 - Auth doc explaining JIMM's authentication and authorisation.
 - How to enable/deploy/use the dashboard.
 - JAAS Limitations - potentially?
 - Relating JIMM and COS stack - general observability.
-- Managing access rights via jimmctl 
 - Documentation on the jaas cli extension snap.
 
 ## Docs requiring changes

--- a/TODO.md
+++ b/TODO.md
@@ -3,23 +3,13 @@
 The following document describes missing JAAS documentation as well as any docs that need to be modernized.
 
 ## Missing Docs
-- ~~Deploy JAAS tutorial~~ (completed in deploy_jimm_microk8s.rst)
 - JAAS architecture
-- ~~Explain the difference between Juju, JAAS and jimmctl CLI tools.~~ (completed in cli_tools.rst)
 - Auth doc explaining JIMM's authentication and authorisation.
 - How to enable/deploy/use the dashboard.
-- JAAS Limitations - potentially (As an example, cross-controller relations don't work with JAAS currently)
+- JAAS Limitations - potentially?
 - Relating JIMM and COS stack - general observability.
-- What versions of Juju controllers and CLI does JIMM support.
 - Managing access rights via jimmctl 
-- How to migrate existing Juju controllers and models to JAAS.
-- How to bootstrap JAAS with an admin user and create user permissions.
-- How to migrate models between Juju controllers in JAAS.
 - Documentation on the jaas cli extension snap.
 
 ## Docs requiring changes
-- how-to/add_controller (possibly merge add_controller_no_dns into the original)
-- how-to/deploy_jimm_k8s
-- how-to/deploy_jimm (the machine charm is not currently on par with the k8s charm, this document could be removed until the machine charm is updated and ready for production use)
-- how-to/route53 ensure this document is still up to date.
-- tutorial/jaas_basics
+

--- a/explanation/index.rst
+++ b/explanation/index.rst
@@ -1,16 +1,19 @@
 Explanation
 ===========
 
+An important precursor to understanding JAAS, is Juju, the open source orchestration engine for software operators.
 
+Read more about Juju over at `their docs <https://juju.is>`__.
+
+JIMM Concepts
+-------------
 .. toctree::
    :maxdepth: 1
 
    JAAS overview <jaas_overview>
+   JAAS architecture <jaas_architecture>
    JAAS tags <jaas_tags>
    JAAS security <jaas_security_scope>
    CLI Tools <cli_tools>
 
-- JIMM - Juju Intelligent Model Manager
-
-- `Juju <https://juju.is>`_
 

--- a/explanation/jaas_architecture.rst
+++ b/explanation/jaas_architecture.rst
@@ -1,0 +1,48 @@
+JAAS Architecture
+=================
+
+This document briefly goes into more detail on JAAS' deployment and scalability.
+
+We recommend first reading the :doc:`JAAS overview <./jaas_overview>` to understand the
+components that make up JAAS.
+
+Deployment
+----------
+
+The components of JAAS are deployed via Juju K8s charms. This implies that in order to deploy JAAS, you
+must first bootstrap a single Juju controller to manage the components of JAAS, this is described in
+more detail in our :doc:`tutorial <../tutorial/deploy_jaas_microk8s>`.
+
+Not all the components of JAAS are expected to be deployed on Kubernetes. With the use of Juju `offers <https://juju.is/docs/juju/manage-offers>`__
+certain components can be deployed to virtual machines and used by the Kubernetes charms. These components 
+include PostgreSQL and Vault and can be deployed with their corresponding machine charms. Currently JIMM
+and OpenFGA are only supported as Kubernetes charms.
+
+Scalability
+-----------
+
+There are several stateless and stateful components to JAAS.
+
+Stateless
+^^^^^^^^^
+
+- JIMM: The JIMM API server.
+- OpenFGA: The OpenFGA API server.
+
+Stateful
+^^^^^^^^
+
+- PostgreSQL: The database used by JIMM and OpenFGA.
+- Vault: The secure key-value store used by JIMM.
+
+Currently, the JIMM, OpenFGA and Vault charms support scaling provided they are deployed on Kubernetes.
+Scaling the database is not currently supported.
+
+Adding more units via Juju is possible with the command ``juju scale-application <application> 2`` to scale an 
+application to N units, 2 in this example.
+
+Communication
+-------------
+
+Communication between clients and JIMM takes place via a websocket based API. This is identical to Juju's communication model
+and enables the same Juju CLI to transparently communicate with a JIMM controller as if it were a Juju controller.

--- a/explanation/jaas_architecture.rst
+++ b/explanation/jaas_architecture.rst
@@ -29,6 +29,10 @@ Stateless
 - JIMM: The JIMM API server.
 - OpenFGA: The OpenFGA API server.
 
+.. note::
+    Although we've put JIMM here as a stateless service, it is partially stateful.
+    See the section on communication for more info. 
+
 Stateful
 ^^^^^^^^
 
@@ -46,3 +50,7 @@ Communication
 
 Communication between clients and JIMM takes place via a websocket based API. This is identical to Juju's communication model
 and enables the same Juju CLI to transparently communicate with a JIMM controller as if it were a Juju controller.
+
+This websocket API makes Juju and JIMM, partially stateful. Once a websocket session is established, authentication is performed
+and the session can be used to make further requests. The nature of this model means that once a connection is established to a
+specific unit of JIMM, that connection cannot be moved without first re-establishing some state.

--- a/explanation/jaas_overview.rst
+++ b/explanation/jaas_overview.rst
@@ -7,8 +7,8 @@ What is JAAS?
 To detail what JAAS is, let's look at what JAAS provides:
 
 - **JAAS** provides a single location to manage your Juju infrastructure by using the 
-  Dashboard or using the same Juju CLI commands to create a high-level overview and 
-  the ability to drill-in to the details when you need it. 
+  Dashboard or using the same Juju CLI commands to create a high-level overview of your deployments 
+  with the ability to drill into the details when you need it. 
 
 - **JAAS** is  useful for organisations running their own Juju infrastructure 
   giving them a single point of contact for their entire real estate and, in combination
@@ -29,8 +29,8 @@ To detail what JAAS is, let's look at what JAAS provides:
 - **JAAS** can query across multiple models at once, giving deeper insights into your estate.
 
 
-Architecture
-------------
+JAAS Components
+---------------
 
 The diagram below shows an overall picture of JAAS architecture.
 
@@ -44,14 +44,14 @@ The diagram below shows an overall picture of JAAS architecture.
 
 .. image:: images/jaas.png
 
-As in the diagram JAAS consists of the following components:
+JAAS consists of the following components:
 
 - Juju Intelligent Model Manager (JIMM)
 - ReBAC authorisation (OpenFGA)
 - Database (PostgreSQL)
 - Secure storage (Vault)
 
-JIMM implements a number of Juju facades and behaves as a *Juju Controller*,
+JIMM is an API server that implements a number of Juju facades (i.e. endpoints) and behaves as a *Juju Controller*,
 which under the hood proxies operations to underlying controllers. This enables
 other tools, like the Juju Dashboard or Juju CLI, that communicate with a 
 Juju Controller to work seamlessly with JIMM.
@@ -59,3 +59,5 @@ Juju Controller to work seamlessly with JIMM.
 For authentication of users or service accounts, JAAS requires an *OIDC Provider*
 (Hydra) that handles the standard OAuth2.0 flows including browser flow, device flow,
 and client credentials.
+
+For more information on the architecture on JAAS and its scalability, check out our :doc:`architecture <./jaas_architecture>` doc.

--- a/how-to/add_controller.rst
+++ b/how-to/add_controller.rst
@@ -1,5 +1,5 @@
-JAAS: Add controller to JIMM
-============================
+JAAS: Add a controller
+======================
 
 
 Introduction

--- a/how-to/index.rst
+++ b/how-to/index.rst
@@ -3,16 +3,16 @@ How-to guides
 
 These how-to guides cover key operations and processes in JAAS.
 
-JIMM Configuration
-------------------
+Configuration
+-------------
 
-After JIMM has been deployed, you need to configure it with your Juju operated cluster.
+After JAAS has been deployed, you need to configure it with your Juju operated cluster.
 
 .. toctree::
    :maxdepth: 1
 
    Bootstrap permissions <bootstrap_permissions>
-   Add a controller to JIMM <add_controller>
+   Add a controller to JAAS <add_controller>
    Migrate models to JAAS <migrate_models>
    Migrate models internally <migrate_models_internal>
 

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -1,7 +1,7 @@
 Reference
 =========
 
-**Technical information** - specifications, APIs, architecture
+**Technical information** - specifications, APIs, and reference docs.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
# Description

This PR adds a doc called `jaas_architecture` which really only covers JAAS' scalability, deployment and a very brief section on communication. The architecture diagram has been kept under `jaas_overview` with some slight renaming.

Some naming in other docs have been adjusted to be more consistent, preferring JAAS over JIMM where possible.