### PR TITLE
fix typos and branch version

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -91,7 +91,7 @@ html_context = {
     'github_url': 'https://github.com/canonical/jaas-documentation',
 
     # Change to the branch for this version of the documentation
-    'github_version': 'main',
+    'github_version': 'v3',
 
     # Change to the folder that contains the documentation
     # (usually "/" or "/docs/")

--- a/index.rst
+++ b/index.rst
@@ -60,10 +60,10 @@ Project and community
 JAAS is a member of the Ubuntu family and warmly welcomes community contributions, suggestions, fixes and constructive feedback.
 
 * `Code of conduct <https://ubuntu.com/community/ethos/code-of-conduct>`_
-* Join the `Mattermost community char <https://chat.charmhub.io/charmhub/channels/jaas>`_
+* Join the `Mattermost community chat <https://chat.charmhub.io/charmhub/channels/jaas>`_
 * Report a bug on `Launchpad <https://bugs.launchpad.net/jaas-issue-tracking>`_
 * Contribute to the :doc:`documentation <contribute>`
-* Visit the `Canonical's careers page <https://canonical.com/careers>`_
+* Visit `Canonical's careers page <https://canonical.com/careers>`_
 
 
 .. toctree::


### PR DESCRIPTION
This PR fixes two typos and updates the `github_version` variable which is used for certain links.