### PR TITLE
docs: jq and yq installantion instructions added to the top

### DIFF
--- a/tutorial/deploy_jaas_microk8s.rst
+++ b/tutorial/deploy_jaas_microk8s.rst
@@ -31,7 +31,7 @@ Install some handy tools.
 
 .. code:: bash
 
-    sudo snap install jq
+    sudo apt install jq
     sudo snap install yq
 
 Setup Juju & MicroK8s

--- a/tutorial/deploy_jaas_microk8s.rst
+++ b/tutorial/deploy_jaas_microk8s.rst
@@ -27,6 +27,13 @@ Start by running the following commands to install and start a Multipass VM, the
     multipass launch jammy --name jimm-deploy [-m 12g -c 4 -d 40G]
     multipass shell jimm-deploy
 
+Install some handy tools.
+
+.. code:: bash
+
+    sudo snap install jq
+    sudo snap install yq
+
 Setup Juju & MicroK8s
 ---------------------
 Now we can install our dependencies, note that Juju 3+ only works with a strictly confined MicroK8s Snap.
@@ -200,12 +207,11 @@ Initialise Vault
 ----------------
 The Vault charm has documentation on how to initialise it `here <https://charmhub.io/vault-k8s/docs/h-getting-started?channel=1.15/beta>`__. But an abridged version of the steps are provided here.
 
-Install the Vault CLI client and the ``yq`` tool.
+Install the Vault CLI client.
 
 .. code:: bash
 
     sudo snap install vault
-    sudo snap install yq
 
 To communicate with the Vault server we now need to setup 3 environment variables:
 


### PR DESCRIPTION
The following command from the [Deploy the identity-bundle section](https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/tutorial/deploy_jaas_microk8s/#deploy-the-identity-bundle) failed without `jq` and `yq` tools installed:
```
TRAEFIK_PUBLIC=$(juju status traefik-public --format yaml | yq .applications.traefik-public.address
```

It might make sense to add `jq` and `yq` installations instructions to the top of the page.