### PR TITLE
Fix Vault charm authorization instructions for newer Vault charm version

### DIFF
--- a/tutorial/deploy_jaas_microk8s.rst
+++ b/tutorial/deploy_jaas_microk8s.rst
@@ -255,7 +255,14 @@ Run the following command to unseal Vault and export the unseal token and root k
     export VAULT_TOKEN=$(echo "$key_init" | sed -n -e 's/.*Root Token: //p'); echo "Root Token = $VAULT_TOKEN"
     export UNSEAL_KEY=$(echo "$key_init" | sed -n -e 's/.*Unseal Key 1: //p'); echo "Unseal Key = $UNSEAL_KEY"
     vault operator unseal "$UNSEAL_KEY"
-    juju run vault/leader authorize-charm token="$VAULT_TOKEN"
+
+Authorizes the charm to be able to interact with Vault to manage its operations.
+
+.. code:: bash
+    vault_secret_id=$(juju add-secret vault-token token="$VAULT_TOKEN")
+    juju grant-secret vault-token vault
+    juju run vault/leader authorize-charm secret-id="$vault_secret_id"
+    juju remove-secret "vault-token"
 
 Now run ``juju status`` again and confirm your Vault unit is in an active state.
 

--- a/tutorial/deploy_jaas_microk8s.rst
+++ b/tutorial/deploy_jaas_microk8s.rst
@@ -259,6 +259,7 @@ Run the following command to unseal Vault and export the unseal token and root k
 Authorizes the charm to be able to interact with Vault to manage its operations.
 
 .. code:: bash
+
     vault_secret_id=$(juju add-secret vault-token token="$VAULT_TOKEN")
     juju grant-secret vault-token vault
     juju run vault/leader authorize-charm secret-id="$vault_secret_id"

--- a/tutorial/deploy_jaas_microk8s.rst
+++ b/tutorial/deploy_jaas_microk8s.rst
@@ -256,7 +256,7 @@ Run the following command to unseal Vault and export the unseal token and root k
     export UNSEAL_KEY=$(echo "$key_init" | sed -n -e 's/.*Unseal Key 1: //p'); echo "Unseal Key = $UNSEAL_KEY"
     vault operator unseal "$UNSEAL_KEY"
 
-Authorizes the charm to be able to interact with Vault to manage its operations.
+Authorises the charm to be able to interact with Vault to manage its operations.
 
 .. code:: bash
 


### PR DESCRIPTION
Newer Vault charm version requires `secret-id` param for the `authorize-charm` action instead of `token` in previous versions.