### PR TITLE
feat: setup new user doc

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -29,6 +29,7 @@ JSON
 Juju
 Kubeflow
 Kubernetes
+localhost
 Launchpad
 LTS
 Makefile
@@ -41,6 +42,7 @@ NodePort
 observability
 OEM
 OLM
+Openstack
 Permalink
 performant
 pre

--- a/how-to/index.rst
+++ b/how-to/index.rst
@@ -15,14 +15,7 @@ After JAAS has been deployed, you need to configure it with your Juju operated c
    Add a controller to JAAS <add_controller>
    Migrate models to JAAS <migrate_models>
    Migrate models internally <migrate_models_internal>
-
-Terraform
----------
-
-.. toctree::
-   :maxdepth: 1
-
-   Use Terraform <use_terraform>
+   Use Terraform for configuration <use_terraform>
 
 Observability
 -------------
@@ -47,3 +40,10 @@ Juju Dashboard
    :maxdepth: 1
 
    How to setup Juju Dashboard <setup_dashboard>
+
+Access
+------
+.. toctree::
+   :maxdepth: 1
+
+   Setup new users <setup_new_users>

--- a/how-to/setup_new_users.rst
+++ b/how-to/setup_new_users.rst
@@ -1,0 +1,69 @@
+JAAS: Setup New Users
+=====================
+
+This how-to describes how a new user can begin to use JAAS to deploy applications.
+
+Prerequisites
+-------------
+
+For this how-to you will need the following:
+
+- A running JAAS environment, see :doc:`our tutorial <../tutorial/deploy_jaas_microk8s>`.
+- A controller connected to JAAS, see :doc:`our how-to <./add_controller>`. This how-to assumes you have added an LXD controller.
+
+Login to JAAS
+-------------
+
+Login to JAAS for the first time:
+
+.. code:: bash
+
+    juju login test-jimm.localhost:443 -c jaas
+
+Running ``juju controllers`` will now show you the ``jaas`` controller.
+Commands like ``juju models`` will now work.
+
+Cloud Credentials
+-----------------
+
+Before we can create a model, your user requires a set of cloud `credentials <https://juju.is/docs/juju/credential>`__.
+
+View credentials available on your client:
+
+.. code:: bash
+
+    juju credentials --client
+
+The output should resemble the following
+
+.. code:: bash
+
+    Client Credentials:
+    Cloud      Credentials
+    localhost  localhost*
+    microk8s   microk8s*
+
+We will upload credentials for LXD - the `localhost` credentials.
+
+.. code:: bash
+
+    juju update-credentials localhost --controller jimm
+
+.. hint::
+
+    For clouds like Openstack or public clouds, use the `juju add-credential` command to interactively
+    add credentials to your client and controller.
+
+Credentials are now available on the controller for your user to deploy models on the LXD cloud.
+
+Deploy
+------
+
+Now we can deploy a model and application:
+
+.. code:: bash
+
+    juju add-model test-model
+    juju deploy ubuntu
+
+We've successfully added a set of cloud-credentials and deployed an application into a model.

--- a/how-to/setup_new_users.rst
+++ b/how-to/setup_new_users.rst
@@ -23,6 +23,29 @@ Login to JAAS for the first time:
 Running ``juju controllers`` will now show you the ``jaas`` controller.
 Commands like ``juju models`` will now work.
 
+Cloud Access
+------------
+
+Verify that you have access to a cloud.
+
+You can check this by running:
+
+.. code:: bash
+
+    juju clouds --controller jimm
+
+The response should resemble:
+
+.. code:: bash
+
+    Clouds available on the controller:
+    Cloud      Regions  Default    Type
+    localhost  1        localhost  lxd 
+
+If no clouds are available, an administrator may need to grant you
+``add-model`` permissions on this cloud. See the `juju grant-cloud <https://juju.is/docs/juju/juju-grant-cloud>`__ 
+command for details.
+
 Cloud Credentials
 -----------------
 

--- a/tutorial/deploy_jaas_microk8s.rst
+++ b/tutorial/deploy_jaas_microk8s.rst
@@ -368,6 +368,7 @@ Now that you have JIMM running you can browse our additional guides to setup an 
 
 - :doc:`Setup your initial JIMM admin and configure permissions<../how-to/bootstrap_permissions>`.
 - :doc:`Learn how to add a new controller to JIMM.<../how-to/add_controller>`
+- :doc:`Learn how to setup your new user.<../how-to/setup_new_users>`
 - :doc:`Learn how to migrate models from existing controllers to JIMM <../how-to/migrate_models>`.
 - :doc:`Understand the difference between the available CLI tools <../explanation/cli_tools>`.
 


### PR DESCRIPTION
This PR introduces a new how-to on getting a new JAAS user ready to deploy models/apps.

I realised there was a gap in our docs after a user followed our tutorial but didn't know how to add cloud-credentials to deploy a model. I think the concepts around "what is a cloud credential" should be fulfilled by Juju documentation and in this new doc for example, I've linked to Juju's doc on cloud credentials.

Resolves [JUJU-7234](https://warthogs.atlassian.net/browse/JUJU-7234)

[JUJU-7234]: https://warthogs.atlassian.net/browse/JUJU-7234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ