### PR TITLE
feat: role management doc

### DIFF
--- a/explanation/jaas_tags.rst
+++ b/explanation/jaas_tags.rst
@@ -31,7 +31,20 @@ A group tag has the following format:
     group-<group id>
 
 where ``group id`` represents the internal ID of the group. Most commonly we
-refer to groups by their group name.
+refer to groups by their name.
+
+Role
+----
+
+A role tag has the following format:
+
+.. code:: console
+
+    role-<role name>
+    role-<role id>
+
+where ``role id`` represents the internal ID of the role. Most commonly we
+refer to role by their name.
 
 Controller
 ----------
@@ -63,7 +76,7 @@ A model tag has the following format:
 where ``controller name`` specifies name of the controller on which the model
 is running and ``model name`` specifies the name of the model.
 
-Application offer
+Application Offer
 -----------------
 
 An application offer tag has the following format:

--- a/explanation/jaas_tags.rst
+++ b/explanation/jaas_tags.rst
@@ -30,8 +30,7 @@ A group tag has the following format:
     group-<group name>
     group-<group id>
 
-where ``group id`` represents the internal ID of the group. Most commonly we
-refer to groups by their name.
+where ``group id`` represents the unique identifier of the group.
 
 Role
 ----
@@ -43,8 +42,7 @@ A role tag has the following format:
     role-<role name>
     role-<role id>
 
-where ``role id`` represents the internal ID of the role. Most commonly we
-refer to role by their name.
+where ``role id`` represents the unique identifier of the role.
 
 Controller
 ----------

--- a/tutorial/group_management.rst
+++ b/tutorial/group_management.rst
@@ -68,7 +68,7 @@ To list all groups known to JAAS run:
 
 .. code:: console
     
-    jimmctl group list
+    jimmctl auth group list
 
 which will show us the three groups we created.
 

--- a/tutorial/index.rst
+++ b/tutorial/index.rst
@@ -8,3 +8,4 @@ This is a collection of tutorials covering JAAS.
 
    Deploy JAAS on MicroK8s <deploy_jaas_microk8s>
    Group and access management <group_management>
+   Role management <role_management>

--- a/tutorial/role_management.rst
+++ b/tutorial/role_management.rst
@@ -1,5 +1,5 @@
-Group and access management
-===========================
+Role management
+===============
 
 Introduction
 ------------
@@ -56,6 +56,12 @@ we will see the ``model-admin`` role.
 Renaming a role **does not** affect role membership or any access rights a role
 might already have in JAAS.
 
+To rename the role, run (the remainer of this doc will assume the name remains as ``model-admin``):
+
+.. code:: console
+
+    jimmctl auth role rename model-admin model-writer
+
 To remove role ``model-admin`` from JAAS, run:
 
 .. code:: console
@@ -68,8 +74,11 @@ Granting access to roles
 Now that we know how to manage roles and roles membership let's take a look
 at how we can grant roles access to resources in JIMM. 
 
-Roles do not currently identical to groups. So our ``model-admin`` role will
-only grant access to specified models.
+This section assumes the ``model-admin`` role was created and ``alice@canonical.com``
+was assigned the role.
+
+Because roles are currently identical to groups, our ``model-admin`` role needs
+to be assigned access to individual resources.
 
 Assuming a model `bob@canonical.com/foo` exists, run:
 
@@ -83,7 +92,7 @@ Now let us check if ``alice@canonical.com`` has administrator access to the mode
 
     jimmctl auth relation check user-alice@canonical.com administrator model-bob@canonical.com/foo
 
-We should get a positive result since ``adam@canonical.com`` is member of role ``model-admin``.
+We should get a positive result since ``alice@canonical.com`` is member of role ``model-admin``.
 
 To remove role ``model-admin``'s access to the model we can run:
 

--- a/tutorial/role_management.rst
+++ b/tutorial/role_management.rst
@@ -21,7 +21,7 @@ Prerequisites
 For this tutorial you will need the following:
 
 - At least one controller connected to JIMM  (see :doc:`../how-to/add_controller`)
-- ``jimmctl`` command (either built from source or installed via a snap)
+- ``jimmctl`` CLI (installed via `Snap <https://snapcraft.io/jimmctl>`__)
 
 Role management
 ----------------
@@ -56,7 +56,7 @@ we will see the ``model-admin`` role.
 Renaming a role **does not** affect role membership or any access rights a role
 might already have in JAAS.
 
-To rename the role, run (the remainer of this doc will assume the name remains as ``model-admin``):
+To rename the role, run (the remainder of this doc will assume the name remains as ``model-admin``):
 
 .. code:: console
 

--- a/tutorial/role_management.rst
+++ b/tutorial/role_management.rst
@@ -1,0 +1,104 @@
+Group and access management
+===========================
+
+Introduction
+------------
+
+.. hint::
+
+    Roles are currently identical to groups in functionality.
+    This tutorial is a summarised version of :doc:`./group_management`.
+
+
+JAAS provides role management capabilities, this allows JAAS 
+administrators to assign roles to users granting them access to resources.
+
+In this tutorial we will show you how to manage roles in JAAS.
+
+Prerequisites
+-------------
+
+For this tutorial you will need the following:
+
+- At least one controller connected to JIMM  (see :doc:`../how-to/add_controller`)
+- ``jimmctl`` command (either built from source or installed via a snap)
+
+Role management
+----------------
+
+For this part of the tutorial we will assume the following user exists in an organisation:
+
+- ``alice@canonical.com``
+
+Next, let us create a role. Run: 
+
+.. code:: console
+
+    jimmctl auth role add model-admin
+
+To assign this role to Alice run:
+
+.. code:: console
+
+    jimmctl auth relation add user-alice@canonical.com assignee role-model-admin
+
+Now Alice is assigned the ``model-admin`` role.
+Note that the role has no permissions yet (see `Granting access to roles`).
+
+To view all available roles run:
+
+.. code:: console
+
+    jimmctl auth role list
+
+we will see the ``model-admin`` role. 
+
+Renaming a role **does not** affect role membership or any access rights a role
+might already have in JAAS.
+
+To remove role ``model-admin`` from JAAS, run:
+
+.. code:: console
+
+    jimmctl auth role remove model-admin
+
+Granting access to roles
+-------------------------
+
+Now that we know how to manage roles and roles membership let's take a look
+at how we can grant roles access to resources in JIMM. 
+
+Roles do not currently identical to groups. So our ``model-admin`` role will
+only grant access to specified models.
+
+Assuming a model `bob@canonical.com/foo` exists, run:
+
+.. code:: console
+
+    jimmctl auth relation add role-model-admin#assignee administrator model-bob@canonical.com/foo
+
+Now let us check if ``alice@canonical.com`` has administrator access to the model by running: 
+
+.. code:: console
+
+    jimmctl auth relation check user-alice@canonical.com administrator model-bob@canonical.com/foo
+
+We should get a positive result since ``adam@canonical.com`` is member of role ``model-admin``.
+
+To remove role ``model-admin``'s access to the model we can run:
+
+.. code:: console
+
+    jimmctl auth relation remove role-model-admin#assignee administrator model-bob@canonical.com/foo
+
+Finally, to list the users who have been assigned the ``model-admin`` role we can run:
+
+.. code:: console
+
+    jimmctl auth relation list --target role-model-admin
+
+Conclusion 
+----------
+
+This tutorial taught you the basics of role management in JAAS. 
+


### PR DESCRIPTION
This PR adds a tutorial on role management.

Note that because roles are currently identical to groups the tutorial is largely just a slimmed down version of the group management tutorial.

Fixes [JUJU-7147](https://warthogs.atlassian.net/browse/JUJU-7147)

[JUJU-7147]: https://warthogs.atlassian.net/browse/JUJU-7147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ