### PR TITLE
chore: fix default highlighting

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -127,6 +127,8 @@ for tag in custom_tags:
 ### Styling
 ############################################################
 
+highlight_language = 'none'
+
 # Find the current builder
 builder = 'dirhtml'
 if '-b' in sys.argv:

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -130,7 +130,8 @@ redirects = {}
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
     'http://test-jimm.localhost/debug/info',
-    'https://matrix.to/#/#jimm:ubuntu.com'
+    'https://matrix.to/#/#jimm:ubuntu.com',
+    'https://jwt.io/introduction' # This link works but returns a 500 from automation.
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
This PR updates the global sphinx config to use no highlighting unless one is specified in code blocks. 
Also fixes a broken link.

Partially fixes https://warthogs.atlassian.net/browse/JUJU-7372