### PR TITLE
Update jimmctl reference doc

### DIFF
--- a/reference/jimmctl.rst
+++ b/reference/jimmctl.rst
@@ -1,4 +1,4 @@
-jimmctl Reference
+``jimmctl`` Reference
 #####################
 
 jimmctl add-cloud-to-controller


### PR DESCRIPTION
This PR contains a generated documentation reference
for the jimmctl CLI tool for release refs/tags/v3.2.2.