### PR TITLE
docs: update homepage project and community, enable give feedback, set up external link icons

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,15 +15,15 @@ JAAS is an enterprise layer on top of [Juju](https://canonical-juju.readthedocs-
 
 JAAS provides:
 
-- The Juju Infinite Model Manager, JIMM (and its [backing charm](https://charmhub.io/juju-jimm-k8s)):  A Juju enterprise-level controller.
+- The Juju Infinite Model Manager, JIMM (and its [backing charm](https://charmhub.io/juju-jimm-k8s)): A Juju enterprise-level controller.
 
 - JIMM-specific extensions to existing Juju machinery, including
 
-  * the {doc}`jaas plugin <./reference/jaas>` which enhances the [`juju` CLI](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/),
+* the {doc}`jaas plugin <./reference/jaas>` which enhances the [`juju` CLI](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/),
 
-  * the [Juju dashboard](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-dashboard/) (and its [backing charm](https://charmhub.io/juju-dashboard), and
+* the [Juju dashboard](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-dashboard/) (and its [backing charm](https://charmhub.io/juju-dashboard), and
 
-  * the [Terraform Provider for Juju](https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/).
+* the [Terraform Provider for Juju](https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/).
 
 When you use an existing Juju on Kubernetes controller to deploy JIMM and its dependencies, and then connect your Juju controllers to JIMM, you gain the ability to:
 
@@ -81,10 +81,15 @@ If you are a site reliability engineer looking to take Juju to the enterprise le
 
 JAAS is a member of the Ubuntu family and warmly welcomes community contributions, suggestions, fixes and constructive feedback.
 
-* Read our [Code of Conduct ](https://ubuntu.com/community/ethos/code-of-conduct)
-* Join our [Matrix chat](https://matrix.to/#/#jimm:ubuntu.com)
-* Join our [Discourse forum](https://discourse.charmhub.io/)
-* Report a bug in the [docs](https://github.com/canonical/jaas-documentation/issues) or the [code](https://github.com/canonical/jimm/issues)
-* Contribute to the [docs](https://github.com/canonical/jaas-documentation/) or the [code](https://github.com/canonical/jimm)
-* Visit the [Juju careers page](https://juju.is/careers)
+* [Release notes](https://github.com/canonical/jimm/releases)
+* [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
+* [Join our chat](https://matrix.to/#/#jimm:ubuntu.com)
+* [Join our forum](https://discourse.charmhub.io/)
+* [Report a bug](https://github.com/canonical/jimm/issues)
+* [Contribute](https://github.com/canonical/jimm/blob/v3/CONTRIBUTING.md)
+* [Visit our careers page](https://juju.is/careers)
+
+Thinking about using Juju for your next project? [Get in touch!](https://canonical.com/contact-us)
+
+
 


### PR DESCRIPTION
In Juju docs and Terraform Provider for Juju docs we have 
- updated the Project and Community section to contain the same standard links in the same link-only fashion, 
- enabled the Give feedback button, and
- enabled external link icons.

This PR replicates all of these featurs in JAAS documentation as well.