### PR TITLE
docs: add releases, give feedback button, external link icons

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -247,6 +247,8 @@ extensions = [
     'sphinxcontrib.lightbox2',
 ]
 
+new_tab_link_show_external_link_icon = True
+
 # Excludes files or directories from processing
 
 exclude_patterns = [

--- a/conf.py
+++ b/conf.py
@@ -101,62 +101,37 @@ ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg
 
 html_context = {
     # Product page URL; can be different from product docs URL
-    #
-    # TODO: Change to your product website URL,
-    #       dropping the 'https://' prefix, e.g. 'ubuntu.com/lxd'.
-    #
-    # TODO: If there's no such website,
-    #       remove the {{ product_page }} link from the page header template
-    #       (usually .sphinx/_templates/header.html; also, see README.rst).
     "product_page": "juju.is/docs",
     # Product tag image; the orange part of your logo, shown in the page header
-    #
-    # TODO: To add a tag image, uncomment and update as needed.
-    # _static is no longer in .sphinx.
-    # For this to work, .sphinx/templates must have base.html defining product_tag.
-    # 'product_tag': '_static/tag.png',
+    # Assumes the current directory is .sphinx.
     'product_tag': '_static/logos/juju-logo-no-text.png',
     # Your Discourse instance URL
-    #
-    # TODO: Change to your Discourse instance URL or leave empty.
-    #
-    # NOTE: If set, adding ':discourse: 123' to an .rst file
-    #       will add a link to Discourse topic 123 at the bottom of the page.
     "discourse": "https://discourse.charmhub.io",
-    # Your Mattermost channel URL
-    #
-    # TODO: Change to your Mattermost channel URL or leave empty.
+    # # Your Mattermost channel URL
     # "mattermost": "",
     # Your Matrix channel URL
-    #
-    # TODO: Change to your Matrix channel URL or leave empty.
     "matrix": "https://matrix.to/#/#jimm:ubuntu.com",
     # Your documentation GitHub repository URL
-    #
-    # TODO: Change to your documentation GitHub repository URL or leave empty.
-    #
-    # NOTE: If set, links for viewing the documentation source files
-    #       and creating GitHub issues are added at the bottom of each page.
     "github_url": "https://github.com/canonical/jaas-documentation",
-    # Docs branch in the repo; used in links for viewing the source files
-    #
-    # TODO: To customise the branch, uncomment and update as needed.
-    'repo_default_branch': 'v3',
+    # Your documentation GitHub issues URL. Required for the Give feedback button.
+    "github_issues": "https://github.com/canonical/jaas-documentation/issues",
+    # 'github_issues': 'enabled',
     # Docs location in the repo; used in links for viewing the source files
-    #
-
-
-    # TODO: To customise the directory, uncomment and update as needed.
     "repo_folder": "/",
-    # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
-    # Valid options: none, prev, next, both
-    # "sequential_nav": "both",
-    # TODO: To enable listing contributors on individual pages, set to True
-    "display_contributors": False,
-
-    # Required for feedback button
-    'github_issues': 'enabled',
+    # Docs branch in the repo; used in links for viewing the source files
+    'repo_default_branch': 'v3',
 }
+
+# TODO: To enable the edit button on pages, uncomment and change the link to a
+# public repository on GitHub or Launchpad. Any of the following link domains
+# are accepted:
+# - https://github.com/example-org/example"
+# - https://launchpad.net/example
+# - https://git.launchpad.net/example
+#
+# html_theme_options = {
+# 'source_edit_link': 'https://github.com/canonical/sphinx-docs-starter-pack',
+# }
 
 # TODO: To enable the edit button on pages, uncomment and change the link to a
 # public repository on GitHub or Launchpad. Any of the following link domains
@@ -179,8 +154,8 @@ html_context = {
 
 # Template and asset locations
 
-html_static_path = ["_static"]
-templates_path = [".sphinx/_templates"]
+# html_static_path = ["_static"]
+# templates_path = [".sphinx/_templates"]
 
 
 #############

--- a/howto/manage-your-jaas-deployment.md
+++ b/howto/manage-your-jaas-deployment.md
@@ -176,12 +176,12 @@ This document shows how to integrate the different components of JAAS with the
 The Canonical Observability Stack is a Juju bundle that includes a series of
 open source observability applications and related automation.
 For the complete list of components in COS, read the
-[Component List](https://documentation.ubuntu.com/observability/explanation/cos-lite/).
+[Stack variants](https://documentation.ubuntu.com/observability/explanation/stack-variants/).
 
 ### Prerequisites
 
 - A running `COS-Lite` bundle.
-  You can follow the [Getting started on MicroK8s](https://documentation.ubuntu.com/observability/tutorial/installation/getting-started-with-cos-lite/) guide.
+  You can follow the [COS tutorial](https://documentation.ubuntu.com/observability/tutorial/) guide.
   tutorial to get you started. Make sure to follow the section **Deploy the COS Lite bundle with overlays** section to create offers.
 - A running JAAS. Please refer to the deployment {doc}`the tutorial <../tutorial/index>`.
 

--- a/index.md
+++ b/index.md
@@ -15,15 +15,15 @@ JAAS is an enterprise layer on top of [Juju](https://canonical-juju.readthedocs-
 
 JAAS provides:
 
-- The Juju Infinite Model Manager, JIMM (and its [backing charm](https://charmhub.io/juju-jimm-k8s)):  A Juju enterprise-level controller.
+- The Juju Infinite Model Manager, JIMM (and its [backing charm](https://charmhub.io/juju-jimm-k8s)): A Juju enterprise-level controller.
 
 - JIMM-specific extensions to existing Juju machinery, including
 
-  * the {doc}`jaas plugin <./reference/jaas>` which enhances the [`juju` CLI](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/),
+* the {doc}`jaas plugin <./reference/jaas>` which enhances the [`juju` CLI](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/),
 
-  * the [Juju dashboard](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-dashboard/) (and its [backing charm](https://charmhub.io/juju-dashboard), and
+* the [Juju dashboard](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-dashboard/) (and its [backing charm](https://charmhub.io/juju-dashboard), and
 
-  * the [Terraform Provider for Juju](https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/).
+* the [Terraform Provider for Juju](https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/).
 
 When you use an existing Juju on Kubernetes controller to deploy JIMM and its dependencies, and then connect your Juju controllers to JIMM, you gain the ability to:
 
@@ -81,10 +81,13 @@ If you are a site reliability engineer looking to take Juju to the enterprise le
 
 JAAS is a member of the Ubuntu family and warmly welcomes community contributions, suggestions, fixes and constructive feedback.
 
-* Read our [Code of Conduct ](https://ubuntu.com/community/ethos/code-of-conduct)
-* Join our [Matrix chat](https://matrix.to/#/#jimm:ubuntu.com)
-* Join our [Discourse forum](https://discourse.charmhub.io/)
-* Report a bug in the [docs](https://github.com/canonical/jaas-documentation/issues) or the [code](https://github.com/canonical/jimm/issues)
-* Contribute to the [docs](https://github.com/canonical/jaas-documentation/) or the [code](https://github.com/canonical/jimm)
-* Visit the [Juju careers page](https://juju.is/careers)
+* [Release notes](https://github.com/canonical/jimm/releases)
+* [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
+* [Join our chat](https://matrix.to/#/#jimm:ubuntu.com)
+* [Join our forum](https://discourse.charmhub.io/)
+* [Report a bug](https://github.com/canonical/jimm/issues)
+* [Contribute](https://github.com/canonical/jimm/blob/v3/CONTRIBUTING.md)
+* [Visit our careers page](https://juju.is/careers)
+
+Thinking about using Juju for your next project? [Get in touch!](https://canonical.com/contact-us)
 


### PR DESCRIPTION
In Juju docs and Terraform Provider for Juju docs we have 
- updated the Project and Community section to contain the same standard links in the same link-only fashion, 
- enabled the Give feedback button, and
- enabled external link icons.

This PR replicates all of these features in JAAS documentation as well.