### PR TITLE
docs: fix template

### DIFF
--- a/.sphinx/_templates/base.html
+++ b/.sphinx/_templates/base.html
@@ -2,7 +2,7 @@
 
 {% block theme_scripts %}
 <script>
-  const product_tag = "{{ product_tag }}";
+  const github_url = "{{ github_url }}";
 </script>
 {% endblock theme_scripts %}
 

--- a/conf.py
+++ b/conf.py
@@ -154,8 +154,8 @@ html_context = {
 
 # Template and asset locations
 
-# html_static_path = ["_static"]
-# templates_path = [".sphinx/_templates"]
+html_static_path = ["_static"]
+templates_path = [".sphinx/_templates"]
 
 
 #############


### PR DESCRIPTION
When trying to enable the Give feedback button in https://github.com/canonical/jaas-documentation/pull/101 , there seemed to be an issue coming from `conf.py`  `html_static_path = ["_static"]` and `templates_path = [".sphinx/_templates"]`, so I commented both out (that was the recommendation from fellow technical authors).

However, since then I've figured out that (1) the template path is required for another update we want to make, namely, analytics (PR forthcoming) and (2) the problem was not with the path but rather with the contents of the template in that path, which contained an outdated key.

This PR fixes the template an reenables the `conf.py` paths.

PS I've checked and, with the fixed template, the Give feedback button works fine.