### PR TITLE
docs: add related links

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,9 @@
+---
+relatedlinks: "[Juju &nbsp; ecosystem &nbsp; docs](https://juju.is/docs), [Terraform &nbsp; Provider &nbsp; Juju &nbsp; docs](https://documentation.ubuntu.com/terraform-provider-juju/), [Jubilant &nbsp; docs](https://documentation.ubuntu.com/jubilant/), [Charmcraft &nbsp; docs](https://documentation.ubuntu.com/charmcraft/), [Ops &nbsp; docs](https://documentation.ubuntu.com/ops/), [Charmlibs &nbsp; docs](https://canonical-charmlibs.readthedocs-hosted.com/)"
+---
+
 (home)=
-# JAAS Documentation
+# JAAS documentation
 
 ```{toctree}
 :maxdepth: 2


### PR DESCRIPTION
Following https://github.com/juju/juju/pull/20358  and https://github.com/juju/terraform-provider-juju/pull/825 , this PR updates the homepage to have a right-hand side RELATED LINKS block with links to all the relevant doc sets.

<img width="259" height="235" alt="image" src="https://github.com/user-attachments/assets/d4ccd0fb-f4a3-4769-ac8c-f567e3085930" />
