### PR TITLE
docs: add juju to related links

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: "[Juju &nbsp; ecosystem &nbsp; docs](https://juju.is/docs), [Terraform &nbsp; Provider &nbsp; Juju &nbsp; docs](https://documentation.ubuntu.com/terraform-provider-juju/), [Jubilant &nbsp; docs](https://documentation.ubuntu.com/jubilant/), [Charmcraft &nbsp; docs](https://documentation.ubuntu.com/charmcraft/), [Ops &nbsp; docs](https://documentation.ubuntu.com/ops/), [Charmlibs &nbsp; docs](https://canonical-charmlibs.readthedocs-hosted.com/)"
+relatedlinks: "[Juju &nbsp; ecosystem &nbsp; docs](https://juju.is/docs), [Juju &nbsp; docs](https://documentation.ubuntu.com/juju/), [Terraform &nbsp; Provider &nbsp; Juju &nbsp; docs](https://documentation.ubuntu.com/terraform-provider-juju/), [Jubilant &nbsp; docs](https://documentation.ubuntu.com/jubilant/), [Charmcraft &nbsp; docs](https://documentation.ubuntu.com/charmcraft/), [Ops &nbsp; docs](https://documentation.ubuntu.com/ops/), [Charmlibs &nbsp; docs](https://canonical-charmlibs.readthedocs-hosted.com/)"
 ---
 
 (home)=


### PR DESCRIPTION
In https://github.com/canonical/jaas-documentation/pull/110 I forgot to add a link to Juju the OLM (not just the ecosystem). Fixing that now.