### PR TITLE
docs: updated related links style, add CONTRIBUTING.md

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -120,6 +120,7 @@ QEMU
 Quickstart
 ReadMe
 ReBAC
+repo
 reST
 reStructuredText
 Rockcraft

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+Thanks for your interest in JAAS documentation -- contributions like yours make good projects
+great!
+
+There are two basic ways to contribute: by opening
+an issue or by creating a PR. This document gives detailed information about
+both.
+
+> Note: If at any point you get stuck, come chat with us on
+[Matrix](https://matrix.to/#/#jimm:ubuntu.com).
+
+## Open an issue
+
+You will need a GitHub account ([sign up](https://github.com/signup)).
+
+### Open an issue for docs
+
+To open an issue for a specific doc, in [the published docs](https://documentation.ubuntu.com/jaas/latest/) find the doc, then use the **Give feedback** button.
+
+To open an issue for docs in general, do the same for the homepage of the docs
+or go to https://github.com/canonical/jaas-documentation/issues, click on **New issue** (top right corner
+of the page), select “Blank issue”, then fill out the issue template and
+submit the issue.
+
+### Open an issue for code
+
+Go to https://github.com/canonical/jaas-documentation/issues  click on **New issue** (top right
+corner of the page), select whatever is appropriate, then fill out the issue
+template and submit the issue.
+
+> Note: For feature requests please use
+https://matrix.to/#/#jimm:ubuntu.com
+
+## Make your first contribution
+
+You will need a GitHub account ([sign up](https://github.com/signup) and [add
+your public SSH key](https://github.com/settings/ssh)) and `git` ([get
+started](https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F)).
+
+Then:
+
+1. [Sign the Canonical Contributor Licence Agreement
+   (CLA)](https://ubuntu.com/legal/contributors).
+
+2. Configure your `git` so your commits are signed:
+
+```
+git config --global user.name "A. Hacker"
+git config --global user.email "a.hacker@example.com"
+git config --global commit.gpgsign true
+```
+
+> See more: [GitHub | Authentication > Signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+
+3. Fork canonical/jaas-documentation. This will create `https://github.com/<user>/jaas-documentation`.
+
+4. Clone your fork locally.
+
+```
+git clone git@github.com:<user>/jaas-documentation.git
+cd jaas-documentation
+```
+
+5. Add a new remote with the name `upstream` and set it to point to the upstream
+`jaas-documentation` repo.
+
+```
+git remote add upstream git@github.com:canonical/jaas-documentation.git
+```
+
+6. Set your local branches to track the `upstream` remote (not your fork). E.g.,
+
+```
+git fetch --all
+git checkout v3
+git branch --set-upstream-to=upstream/v3
+```
+
+7. Sync your local branches with the upstream, then check out the branch you
+want to contribute to and create a feature branch based on it.
+
+```
+git fetch upstream
+git checkout v3
+git pull
+git checkout -b v3-new-stuff # your feature branch
+```
+
+8. Make the desired changes: All changes should follow the existing patterns, including
+[Diátaxis](https://diataxis.fr), the [Canonical Documentation Style
+Guide](https://docs.ubuntu.com/styleguide/en), the modular structure, the
+cross-referencing pattern, [MyST
+Markdown](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/myst-syntax-reference/),
+etc.
+
+Test changes locally: Changes should be inspected by building the docs and fixing any issues
+discovered that way. To preview the docs as they will be rendered on RTD, run
+`make run` and open the provided link in a browser. If you get errors, try `make
+clean`, then `make run` again. For other checks, see `make [Tab]` and select the
+command for the desired check.
+
+9. As you make your changes, ensure that you always remain in sync with the upstream:
+
+```
+git pull upstream v3 --rebase
+git push --force
+```
+
+10. Stage, commit and push regularly to your fork. Make sure your commit messages
+comply with conventional commits ([see upstream
+standard](https://www.conventionalcommits.org/en/v1.0.0/)). E.g.,
+
+```
+git add .
+git commit -m "docs: add setup and teardown anchors"
+git push origin v3-new-stuff
+```
+
+> Tip: If you've set things up correctly, typing just `git push` and returning
+may be enough for `git` to prompt you with the correct arguments.
+
+> Tip: If you don't want to create a new commit message every time, do
+`git commit --amend --no-edit`, then `git push --force`. However, be careful with this,
+as it overwrites your commit.
+
+11. Create the PR.
+
+12. Ensure GitHub tests pass.
+
+13. In [the Matrix JIMM
+channel](https://matrix.to/#/#jimm:ubuntu.com), drop a link to your
+PR with the mention that it needs reviews. Someone will review your PR. Make all
+the requested changes.
+
+14. When you've received one approval, your PR can be merged. Depending on your
+repo access, at this point you may be able to merge directly (by clicking on
+Merge pull request). Otherwise, ping one of your reviewers and ask them to help
+merge.
+
+> Tip: After your first contribution, you will only have to repeat steps 7-14.
+
+Congratulations and thank you!
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,9 @@ submit the issue.
 
 ### Open an issue for code
 
-Go to https://github.com/canonical/jaas-documentation/issues  click on **New issue** (top right
+Go to https://github.com/canonical/jimm/issues click on **New issue** (top right
 corner of the page), select whatever is appropriate, then fill out the issue
 template and submit the issue.
-
-> Note: For feature requests please use
-https://matrix.to/#/#jimm:ubuntu.com
 
 ## Make your first contribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# How to contribute to JAAS documentation
+
 Thanks for your interest in JAAS documentation -- contributions like yours make good projects
 great!
 

--- a/conf.py
+++ b/conf.py
@@ -266,8 +266,9 @@ new_tab_link_show_external_link_icon = True
 # Excludes files or directories from processing
 
 exclude_patterns = [
+  'CONTRIBUTING.md',
   'TODO.md',
-  'README.md'
+  'README.md',
 ]
 
 # Add CSS files (located in .sphinx/_static/)

--- a/explanation/reference-architecture.md
+++ b/explanation/reference-architecture.md
@@ -194,7 +194,7 @@ In case of data loss or outage, restore things as follows:
 
 When a new stable version of Juju is released, you should upgrade all your managed models to the new version.
 
-For patch version upgrades you can follow Juju’s in-place upgrade procedure to upgrade individual controllers followed by upgrades of individual models. [See more.](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#upgrade-your-deployment)
+For patch version upgrades you can follow Juju’s in-place upgrade procedure to upgrade individual controllers followed by upgrades of individual models. {external+juju:ref}`See more. <upgrade-your-deployment>`
 
 Minor and major version upgrades of Juju controllers are not supported -- instead you must bootstrap a new Juju controller of a specific version, add it to JIMM, and migrate all your existing models to this controller. [See more.](https://documentation.ubuntu.com/jaas/v3/howto/manage-models/#migrate-a-model-within-jaas)
 

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: "[Juju &nbsp; ecosystem &nbsp; docs](https://juju.is/docs), [Juju &nbsp; docs](https://documentation.ubuntu.com/juju/), [Terraform &nbsp; Provider &nbsp; Juju &nbsp; docs](https://documentation.ubuntu.com/terraform-provider-juju/), [Jubilant &nbsp; docs](https://documentation.ubuntu.com/jubilant/), [Charmcraft &nbsp; docs](https://documentation.ubuntu.com/charmcraft/), [Ops &nbsp; docs](https://documentation.ubuntu.com/ops/), [Charmlibs &nbsp; docs](https://canonical-charmlibs.readthedocs-hosted.com/)"
+relatedlinks: "[Charmcraft](https://documentation.ubuntu.com/charmcraft/), [Charmlibs](https://canonical-charmlibs.readthedocs-hosted.com/), [Concierge](https://github.com/canonical/concierge), [Jubilant](https://documentation.ubuntu.com/jubilant/), [Juju](https://documentation.ubuntu.com/juju/), [Ops](https://documentation.ubuntu.com/ops/), [Pebble](https://documentation.ubuntu.com/pebble/), [Terraform &nbsp; Provider &nbsp; for &nbsp; Juju](https://documentation.ubuntu.com/terraform-provider-juju/)"
 ---
 
 (home)=


### PR DESCRIPTION
The related links on the homepage try to follow an olm/sdk logic, but that doesn't work well when you add Jubilant and Concierge. This PR updates it to alphabetical order.  (We're doing this for all our doc sets.)

This repo has no CONTRIBUTING. This PR adds it.